### PR TITLE
Removed quotes from integer math operations

### DIFF
--- a/titty
+++ b/titty
@@ -44,10 +44,10 @@ tdisp(){
 	total=0
 	while read -r NAME START STOP
 	do
-		if [ "$1" = 'all' ] || [ "$(date --date=@"$START" +"$FMTSTRING")" -eq "$(date +"$FMTSTRING")" ]
+		if [ "$1" = 'all' ] || [ "$(date --date=@$START +$FMTSTRING)" -eq "$(date +$FMTSTRING)" ]
 		then
-			TIME=$(("$STOP" - "$START"))
-			total=$(("$total" + "$TIME"))
+			TIME=$(($STOP - $START))
+			total=$(($total + $TIME))
 			printf  "%-25s\t%25s\n" "$NAME" "$(hms "$TIME")"
 		fi 
 	done < "$masterlist"
@@ -100,7 +100,7 @@ tbackstart(){
 	STARTTIME="$(date -d "$(date -d "-$2")" +%s)"
 	if tcheck_tracking
 	then
-		printf "%s|%s" "$1" "$STARTTIME" >> "$masterlist"
+		printf "%s|%s" "$1" $STARTTIME >> $masterlist
 		printf "%s\n" "Started at $(date --date=@"$STARTTIME")"
 	else
 		printf "%s\n" "Time is already being tracked ya doofus!"
@@ -120,7 +120,7 @@ tstart(){
 		else
 			task_name="$1"
 		fi
-		printf "%s|%s" "$task_name" "$STARTTIME" >> "$masterlist"
+		printf "%s|%s" "$task_name" $STARTTIME >> $masterlist
 		printf "%s\n" "Started at $(date --date=@"$STARTTIME")"
 	else
 		printf "%s\n" "Time is already being tracked ya doofus!"
@@ -136,7 +136,7 @@ tstop(){
 		IFS="|" read -r NAME STARTTIME < "$tmp"
 		rm "$tmp"
 		printf "%s\n" "|$STOPTIME" >> "$masterlist"
-		TIMETAKEN=$(("$STOPTIME" - "$STARTTIME"))
+		TIMETAKEN=$(($STOPTIME - $STARTTIME))
 		printf "%s\n" "Stopped - $(hms $TIMETAKEN) tracked for $NAME"
 	else
 		printf "%s\n" "You never started tracking the time, dummy!"
@@ -155,7 +155,7 @@ tstatus(){
 		tail -n1 "$CONFIG_DIR"/masterlist > "$tmp"
 		IFS="|" read -r NAME STARTTIME < "$tmp"
 		rm "$tmp"
-		TIMETAKEN=$(("$CURRENT_TIME" - "$STARTTIME"))
+		TIMETAKEN=$(($CURRENT_TIME - $STARTTIME))
 		printf "%s\n" "$(hms $TIMETAKEN) tracked for $NAME"
 	else
 		printf "%s\n" "You never started tracking the time, dummy!"


### PR DESCRIPTION
Thank you for creating a very nice script!

In my bash the quotes around the time calculations causes errors, such as `/bin/titty: 49: arithmetic expression: expecting primary: ""1634273250" - "1634273183""`

Removing the quotes from such operations fixes the issue.

This is on GNU bash, version 5.1.4(1)-release