### PR TITLE
Fix date command for macOS compatibility

### DIFF
--- a/tt
+++ b/tt
@@ -45,7 +45,7 @@ tdisp(){
 	total_income=0
 	while read -r NAME START RATE STOP
 	do
-		if [ "$1" = 'all' ] || [ "$(date --date=@"$START" +"$FMTSTRING")" -eq "$(date +"$FMTSTRING")" ]
+		if [ "$1" = 'all' ] || [ "$(date -j -f "%s" "$START" +"$FMTSTRING")" -eq "$(date +"$FMTSTRING")" ]
 		then
 			TIME=$((STOP - START))
 			total=$((total + TIME))
@@ -101,11 +101,11 @@ exit
 }
 
 tbackstart(){
-	STARTTIME="$(date -d "$(date -d "-$2")" +%s)"
+	STARTTIME="$(date -v -"$2" +%s)"
 	if tcheck_tracking
 	then
 		printf "%s|%s" "$1" "$STARTTIME" >> "$masterlist"
-		printf "%s\n" "Started at $(date --date=@"$STARTTIME")"
+		printf "%s\n" "Started at $(date -j -f "%s" "$STARTTIME")"
 	else
 		printf "%s\n" "Time is already being tracked ya doofus!"
 	fi
@@ -128,8 +128,8 @@ tstart(){
 			printf 'Rate($/hour) - only enter the number: '
 			read -r rate
 		fi
-		printf "%s|%s|%s" "$task_name - $(date --iso)" "$STARTTIME" "$rate" >> "$masterlist"
-		printf "%s\n" "Started at $(date --date=@"$STARTTIME") for $rate per hour"
+		printf "%s|%s|%s" "$task_name - $(date +%Y-%m-%d)" "$STARTTIME" "$rate" >> "$masterlist"
+		printf "%s\n" "Started at $(date -j -f "%s" "$STARTTIME") for $rate per hour"
 	else
 		printf "%s\n" "Time is already being tracked ya doofus!"
 	fi


### PR DESCRIPTION
Related to #9

Update the `date` command in the `tt` script to be compatible with macOS.

* Modify the `date` command in the `tbackstart` function to use the `-v` option instead of `-d`.
* Modify the `date` command in the `tstart` function to use the `+%Y-%m-%d` format instead of `--iso`.
* Modify the `date` command in the `tdisp` function to use the `-j -f` options instead of `--date`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/gtlsgamr/tt/issues/9?shareId=4fea40cc-45d4-415f-a878-99ded4df4a13).